### PR TITLE
Bump monitoring to v9.0.3

### DIFF
--- a/monitoring.sh
+++ b/monitoring.sh
@@ -1,6 +1,6 @@
 package: Monitoring
 version: "%(tag_basename)s"
-tag: v3.4.0
+tag: v9.0.3
 requires:
   - boost
   - "GCC-Toolchain:(?!osx)"


### PR DESCRIPTION
Auto-generated PR for the following release https://github.com/awegrzyn/Monitoring/releases/tag/v9.0.3